### PR TITLE
Update workflow to use github actions account to commit changes

### DIFF
--- a/.github/workflows/update_json.yml
+++ b/.github/workflows/update_json.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,8 +25,8 @@ jobs:
           python3 scraper/src/status.py
       - name: Commit files
         run: |
-          git config --local user.email "matthewzalex@gmail.com"
-          git config --local user.name "github-actions[bot]"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add .
           git diff --staged --quiet || git commit -am "🌍 Update JSON - $(date -d '+5 hours +30 minutes' +'%d %b %Y | %I:%M %p')"
           git push


### PR DESCRIPTION
### Changes

- Use github actions account to commit changes instead of an actual users account.
- Add contents write permission to achieve the same.